### PR TITLE
Job whitelisting

### DIFF
--- a/OSMTM/__init__.py
+++ b/OSMTM/__init__.py
@@ -30,7 +30,7 @@ def main(global_config, **settings):
     config.add_route('login', '/login')
     config.add_route('logout', '/logout')
     config.add_route('job_new', '/job/new')
-    config.add_route('job', '/job/{id}', factory='OSMTM.resources.JobFactory')
+    config.add_route('job', '/job/{job}', factory='OSMTM.resources.JobFactory')
     config.add_route('task', '/job/{job}/task/{x}/{y}', factory='OSMTM.resources.JobFactory')
     config.add_route('task_unlock', '/job/{job}/task/{x}/{y}/unlock', factory='OSMTM.resources.JobFactory')
     config.add_route('task_done', '/job/{job}/task/{x}/{y}/done', factory='OSMTM.resources.JobFactory')

--- a/OSMTM/__init__.py
+++ b/OSMTM/__init__.py
@@ -5,7 +5,6 @@ from pyramid.authentication import AuthTktAuthenticationPolicy
 from pyramid.authorization import ACLAuthorizationPolicy
 
 from OSMTM.models import initialize_sql, group_membership
-from OSMTM.resources import JobResource
 
 def main(global_config, **settings):
     """ This function returns a Pyramid WSGI application.

--- a/OSMTM/__init__.py
+++ b/OSMTM/__init__.py
@@ -31,6 +31,7 @@ def main(global_config, **settings):
     config.add_route('logout', '/logout')
     config.add_route('job_new', '/job/new')
     config.add_route('job', '/job/{job}', factory='OSMTM.resources.JobFactory')
+    config.add_route('job_users', '/job/{job}/users', factory='OSMTM.resources.JobFactory')
     config.add_route('task', '/job/{job}/task/{x}/{y}', factory='OSMTM.resources.JobFactory')
     config.add_route('task_unlock', '/job/{job}/task/{x}/{y}/unlock', factory='OSMTM.resources.JobFactory')
     config.add_route('task_done', '/job/{job}/task/{x}/{y}/done', factory='OSMTM.resources.JobFactory')

--- a/OSMTM/__init__.py
+++ b/OSMTM/__init__.py
@@ -5,6 +5,7 @@ from pyramid.authentication import AuthTktAuthenticationPolicy
 from pyramid.authorization import ACLAuthorizationPolicy
 
 from OSMTM.models import initialize_sql, group_membership
+from OSMTM.resources import JobResource
 
 def main(global_config, **settings):
     """ This function returns a Pyramid WSGI application.
@@ -29,11 +30,11 @@ def main(global_config, **settings):
     config.add_route('login', '/login')
     config.add_route('logout', '/logout')
     config.add_route('job_new', '/job/new')
-    config.add_route('job', '/job/{id}')
-    config.add_route('task', '/job/{job}/task/{x}/{y}')
-    config.add_route('task_unlock', '/job/{job}/task/{x}/{y}/unlock')
-    config.add_route('task_done', '/job/{job}/task/{x}/{y}/done')
-    config.add_route('task_take', '/job/{job}/take')
+    config.add_route('job', '/job/{id}', factory='OSMTM.resources.JobFactory')
+    config.add_route('task', '/job/{job}/task/{x}/{y}', factory='OSMTM.resources.JobFactory')
+    config.add_route('task_unlock', '/job/{job}/task/{x}/{y}/unlock', factory='OSMTM.resources.JobFactory')
+    config.add_route('task_done', '/job/{job}/task/{x}/{y}/done', factory='OSMTM.resources.JobFactory')
+    config.add_route('task_take', '/job/{job}/take', factory='OSMTM.resources.JobFactory')
     config.add_route('profile', '/profile')
     config.add_route('profile_update', '/profile/update')
     config.add_route('user', '/user/{id}')

--- a/OSMTM/models.py
+++ b/OSMTM/models.py
@@ -69,6 +69,19 @@ job_whitelist_table = Table('job_whitelists', Base.metadata,
     Column('user_id', Unicode, ForeignKey('users.username'))
 )
 
+class User(Base):
+    __tablename__ = "users"
+    username = Column(Unicode, primary_key=True)
+    role = Column(Integer) # 1 - newbie, 2 - advanced, 3 - admin
+    task = relationship(Tile, backref='user')
+
+    def __init__(self, username, role=1):
+        self.username = username
+        self.role = role
+
+    def is_admin(self):
+        return self.role == 3
+
 class Job(Base):
     """ The SQLAlchemy declarative model class for a Page object. """
     __tablename__ = 'jobs'
@@ -91,19 +104,6 @@ class Job(Base):
         self.workflow = workflow
         self.zoom = zoom
         self.is_private = is_private
-
-class User(Base):
-    __tablename__ = "users"
-    username = Column(Unicode, primary_key=True)
-    role = Column(Integer) # 1 - newbie, 2 - advanced, 3 - admin
-    task = relationship(Tile, backref='user')
-
-    def __init__(self, username, role=1):
-        self.username = username
-        self.role = role
-
-    def is_admin(self):
-        return self.role == 3
 
 def group_membership(username, request):
     session = DBSession()

--- a/OSMTM/models.py
+++ b/OSMTM/models.py
@@ -34,6 +34,7 @@ Base = declarative_base()
 class RootFactory(object):
     __acl__ = [ (Allow, Everyone, 'view'),
                 (Allow, Authenticated, 'edit'),
+                (Allow, Authenticated, 'job'),
                 (Allow, 'group:admin', 'admin') ]
     def __init__(self, request):
         pass

--- a/OSMTM/models.py
+++ b/OSMTM/models.py
@@ -3,6 +3,7 @@ import transaction
 from sqlalchemy import Column
 from sqlalchemy import Integer
 from sqlalchemy import Unicode
+from sqlalchemy import Boolean
 from sqlalchemy import DateTime
 from sqlalchemy import Table
 from sqlalchemy import Column
@@ -71,14 +72,17 @@ class Job(Base):
     geometry = Column(Unicode)
     workflow = Column(Unicode)
     zoom = Column(Integer)
+    is_private = Column(Boolean)
     tiles = relationship(Tile, backref='job')
+    users = relationship(User)
 
-    def __init__(self, title=None, description=None, geometry=None, workflow=None, zoom=None):
+    def __init__(self, title=None, description=None, geometry=None, workflow=None, zoom=None, is_private=False):
         self.title = title
         self.description = description
         self.geometry = geometry
         self.workflow = workflow
         self.zoom = zoom
+        self.is_private = is_private
 
 class User(Base):
     __tablename__ = "users"
@@ -106,7 +110,7 @@ def populate():
     session = DBSession()
     user = User('foo', 1)
     session.add(user)
-    job = Job('SomeTitle', 'Some description', 'Some workflow', 'Some geometry', 10)
+    job = Job('SomeTitle', 'Some description', 'Some workflow', 'Some geometry', 10, False)
     session.add(job)
     
 def initialize_sql(engine):

--- a/OSMTM/resources.py
+++ b/OSMTM/resources.py
@@ -1,0 +1,14 @@
+from pyramid.security import Allow, Deny, Everyone
+from models import Job, User, RootFactory, DBSession
+
+class JobFactory(RootFactory):
+    def __init__(self, request):
+        session = DBSession()
+        job_id = request.matchdict['job']
+        job = session.query(Job).get(job_id)
+        if job.is_private:
+            acl = [
+                (Allow, ('group:admin', 'job:'+job_id), 'job'),
+                (Deny, Everyone, 'job'),
+            ]
+            self.__acl__ = acl + self.__acl__.clone()

--- a/OSMTM/resources.py
+++ b/OSMTM/resources.py
@@ -11,4 +11,4 @@ class JobFactory(RootFactory):
                 (Allow, ('group:admin', 'job:'+job_id), 'job'),
                 (Deny, Everyone, 'job'),
             ]
-            self.__acl__ = acl + self.__acl__.clone()
+            self.__acl__ = acl + list(self.__acl__)

--- a/OSMTM/resources.py
+++ b/OSMTM/resources.py
@@ -8,7 +8,8 @@ class JobFactory(RootFactory):
         job = session.query(Job).get(job_id)
         if job.is_private:
             acl = [
-                (Allow, ('group:admin', 'job:'+job_id), 'job'),
+                (Allow, 'job:'+job_id, 'job'),
+                (Allow, 'group:admin', 'job'),
                 (Deny, Everyone, 'job'),
             ]
             self.__acl__ = acl + list(self.__acl__)

--- a/OSMTM/templates/home.mako
+++ b/OSMTM/templates/home.mako
@@ -6,7 +6,7 @@
         <ul>
         % if jobs:
             % for job in jobs:
-                <li><a href="${request.route_url('job', id=job.id)}">${job.title}</a></li>
+                <li><a href="${request.route_url('job', job=job.id)}">${job.title}</a></li>
             % endfor
         % else:
             <li>No job to show</li>

--- a/OSMTM/templates/job.new.mako
+++ b/OSMTM/templates/job.new.mako
@@ -40,7 +40,7 @@
             </div> 
             <div class="field">
             <label for="id_is_private">Is private?</label>
-            <input type="checkbox" id="id_is_private" name="is_private" />
+            <input type="checkbox" id="id_is_private" name="is_private" value="1" />
             </div>
             <div class="field">
             <input type="submit" class="submit" value="Create the job" id="id_submit" name="form.submitted" disabled="disabled"/> 

--- a/OSMTM/templates/job.new.mako
+++ b/OSMTM/templates/job.new.mako
@@ -39,6 +39,10 @@
             </select>
             </div> 
             <div class="field">
+            <label for="id_is_private">Is private?</label>
+            <input type="checkbox" id="id_is_private" name="is_private" />
+            </div>
+            <div class="field">
             <input type="submit" class="submit" value="Create the job" id="id_submit" name="form.submitted" disabled="disabled"/> 
             </div>
         </form>

--- a/OSMTM/templates/job.users.mako
+++ b/OSMTM/templates/job.users.mako
@@ -6,9 +6,9 @@
     <section class="job">
         <h1>Job whitelist: ${job.title}</h1>
         <p>This job is
-        % if job.is_private
+        % if job.is_private:
         private.
-        % else
+        % else:
         public.
         % endif
         </p>
@@ -16,7 +16,7 @@
             <div class="field"> 
                 <label for="id_username">Add a user:</label> 
                 <select id="id_username" name="username">
-                % for user in all_users
+                % for user in all_users:
                 <option value="${user.username}">${user.username}</option>
                 % endfor
                 </select>
@@ -24,7 +24,7 @@
             </div>
         </form>
         <ul>
-        % for user in job.users
+        % for user in job.users:
             <li>${user.username}</li>
         % endfor
         </ul>

--- a/OSMTM/templates/job.users.mako
+++ b/OSMTM/templates/job.users.mako
@@ -1,0 +1,32 @@
+<%inherit file="/base.mako"/>
+<%def name="id()">job_users</%def>
+<%def name="title()">Job whitelist - ${job.title}</%def>
+
+<div class="content group wrap">
+    <section class="job">
+        <h1>Job whitelist: ${job.title}</h1>
+        <p>This job is
+        % if job.is_private
+        private.
+        % else
+        public.
+        % endif
+        </p>
+        <form method="post" action="">
+            <div class="field"> 
+                <label for="id_username">Add a user:</label> 
+                <select id="id_username" name="username">
+                % for user in all_users
+                <option value="${user.username}">${user.username}</option>
+                % endfor
+                </select>
+                <input type="submit" class="submit" value="Add" id="id_submit" name="form.submitted" /> 
+            </div>
+        </form>
+        <ul>
+        % for user in job.users
+            <li>${user.username}</li>
+        % endfor
+        </ul>
+    </section>
+</div>

--- a/OSMTM/templates/task.mako
+++ b/OSMTM/templates/task.mako
@@ -3,7 +3,7 @@
 <%def name="title()">Tile - ${tile.x} / ${tile.y}</%def>
 <div class="content group wrap">
     <section class="task">
-        <h1>Job: <a href="${request.route_url('job', id=tile.job_id)}">${tile.job.title}</a></h1>
+        <h1>Job: <a href="${request.route_url('job', job=tile.job_id)}">${tile.job.title}</a></h1>
         <div>${tile.x} / ${tile.y}</div>
         <div id="export">
             Open with <a href="javascript:void(0);" id="josm">JOSM</a>, 

--- a/OSMTM/views/tasks.py
+++ b/OSMTM/views/tasks.py
@@ -43,7 +43,7 @@ def task(request):
             time_left=time_left,
             feature=dumps(polygon),
             user=user,
-            job_url=request.route_url('job', id=job_id),
+            job_url=request.route_url('job', job=job_id),
             done_url=request.route_url('task_done', job=job_id, x=x, y=y))
 
 @view_config(route_name='task_done', permission='job', renderer='json')
@@ -64,7 +64,7 @@ def done(request):
         user = session.query(User).get(username)
         tile.checkin = int(user.role)
     session.add(tile)
-    return HTTPFound(location=request.route_url('job', id=job_id))
+    return HTTPFound(location=request.route_url('job', job=job_id))
 
 @view_config(route_name='task_unlock', permission='job')
 def unlock(request):
@@ -76,7 +76,7 @@ def unlock(request):
     tile.username = None 
     tile.checkout = None 
     session.add(tile)
-    return HTTPFound(location=request.route_url('job', id=job_id))
+    return HTTPFound(location=request.route_url('job', job=job_id))
 
 @view_config(route_name='task_take', permission='job')
 def take(request):
@@ -89,7 +89,7 @@ def take(request):
     tiles = session.query(Tile).filter(filter).all()
     if len(tiles) > 0:
         request.session.flash('You already have a task to work on. Finish it before you can accept a new one.')
-        return HTTPFound(location=request.route_url('job', id=job_id))
+        return HTTPFound(location=request.route_url('job', job=job_id))
 
     filter = and_(Tile.checkin==int(user.role) - 1, Tile.job_id==job_id)
     tiles = session.query(Tile).filter(filter).all()

--- a/OSMTM/views/tasks.py
+++ b/OSMTM/views/tasks.py
@@ -22,7 +22,7 @@ from pyramid.security import authenticated_userid
 import logging
 log = logging.getLogger(__file__)
 
-@view_config(route_name='task', renderer='task.mako', permission='edit')
+@view_config(route_name='task', renderer='task.mako', permission='job')
 def task(request):
     job_id = request.matchdict['job']
     x = request.matchdict['x']
@@ -46,7 +46,7 @@ def task(request):
             job_url=request.route_url('job', id=job_id),
             done_url=request.route_url('task_done', job=job_id, x=x, y=y))
 
-@view_config(route_name='task_done', permission='edit', renderer='json')
+@view_config(route_name='task_done', permission='job', renderer='json')
 def done(request):
     job_id = request.matchdict['job']
     x = request.matchdict['x']
@@ -66,7 +66,7 @@ def done(request):
     session.add(tile)
     return HTTPFound(location=request.route_url('job', id=job_id))
 
-@view_config(route_name='task_unlock', permission='edit')
+@view_config(route_name='task_unlock', permission='job')
 def unlock(request):
     job_id = request.matchdict['job']
     x = request.matchdict['x']
@@ -78,7 +78,7 @@ def unlock(request):
     session.add(tile)
     return HTTPFound(location=request.route_url('job', id=job_id))
 
-@view_config(route_name='task_take', permission='edit')
+@view_config(route_name='task_take', permission='job')
 def take(request):
     job_id = request.matchdict['job']
     session = DBSession()

--- a/OSMTM/views/views.py
+++ b/OSMTM/views/views.py
@@ -108,9 +108,9 @@ def logout(request):
 @view_config(route_name='home', renderer='home.mako', permission='edit')
 def home(request):
     session = DBSession()
-    jobs = session.query(Job).all()
     username = authenticated_userid(request)
     user = session.query(User).get(username)
+    jobs = [job for job in session.query(Job).all() if not job.is_private] + user.private_jobs
     return dict(jobs=jobs,
             user=user,
             admin=user.is_admin())

--- a/OSMTM/views/views.py
+++ b/OSMTM/views/views.py
@@ -110,7 +110,9 @@ def home(request):
     session = DBSession()
     username = authenticated_userid(request)
     user = session.query(User).get(username)
-    jobs = [job for job in session.query(Job).all() if not job.is_private] + user.private_jobs
+    jobs = session.query(Job).all()
+    if not user.is_admin():
+        jobs = [job for job in jobs if not job.is_private] + user.private_jobs
     return dict(jobs=jobs,
             user=user,
             admin=user.is_admin())
@@ -165,7 +167,7 @@ def job(request):
             current_task=current_task,
             admin=user.is_admin())
 
-@view_config(route_name='job_users', renderer='job.mako', permission='admin')
+@view_config(route_name='job_users', renderer='job.users.mako', permission='admin')
 def job_users(request):
     id = request.matchdict['job']
     session = DBSession()

--- a/OSMTM/views/views.py
+++ b/OSMTM/views/views.py
@@ -139,7 +139,7 @@ def job_new(request):
 
 @view_config(route_name='job', renderer='job.mako', permission='edit')
 def job(request):
-    id = request.matchdict['id']
+    id = request.matchdict['job']
     session = DBSession()
     job = session.query(Job).get(id)
     tiles = []

--- a/OSMTM/views/views.py
+++ b/OSMTM/views/views.py
@@ -126,7 +126,7 @@ def job_new(request):
         job.geometry = request.params['geometry']
         job.workflow = request.params['workflow']
         job.zoom = request.params['zoom']
-        job.is_private = request.params['is_private']
+        job.is_private = request.params['is_private'] or 0
 
         tiles = []
         for i in get_tiles_in_geom(loads(job.geometry), int(job.zoom)):

--- a/OSMTM/views/views.py
+++ b/OSMTM/views/views.py
@@ -135,7 +135,7 @@ def job_new(request):
 
         session.add(job)
         session.flush()
-        return HTTPFound(location = route_url('job', request, id=job.id))
+        return HTTPFound(location = route_url('job', request, job=job.id))
     return {} 
 
 @view_config(route_name='job', renderer='job.mako', permission='job')

--- a/OSMTM/views/views.py
+++ b/OSMTM/views/views.py
@@ -137,7 +137,7 @@ def job_new(request):
         return HTTPFound(location = route_url('job', request, id=job.id))
     return {} 
 
-@view_config(route_name='job', renderer='job.mako', permission='edit')
+@view_config(route_name='job', renderer='job.mako', permission='job')
 def job(request):
     id = request.matchdict['job']
     session = DBSession()

--- a/OSMTM/views/views.py
+++ b/OSMTM/views/views.py
@@ -126,7 +126,7 @@ def job_new(request):
         job.geometry = request.params['geometry']
         job.workflow = request.params['workflow']
         job.zoom = request.params['zoom']
-        job.is_private = request.params['is_private'] or 0
+        job.is_private = request.params.get('is_private', 0)
 
         tiles = []
         for i in get_tiles_in_geom(loads(job.geometry), int(job.zoom)):

--- a/OSMTM/views/views.py
+++ b/OSMTM/views/views.py
@@ -116,7 +116,7 @@ def home(request):
             admin=user.is_admin())
 
 @view_config(route_name='job_new', renderer='job.new.mako',
-        permission='edit')
+        permission='admin')
 def job_new(request):
     if 'form.submitted' in request.params:
         session = DBSession()

--- a/OSMTM/views/views.py
+++ b/OSMTM/views/views.py
@@ -165,6 +165,23 @@ def job(request):
             current_task=current_task,
             admin=user.is_admin())
 
+@view_config(route_name='job_users', renderer='job.mako', permission='admin')
+def job_users(request):
+    id = request.matchdict['job']
+    session = DBSession()
+    job = session.query(Job).get(id)
+    if 'form.submitted' in request.params:
+        username = request.params['username']
+        user = session.query(User).get(username)
+        if user:
+            job.users.append(user)
+            session.flush()
+            request.session.flash('User "%s" added to the whitelist!' % username)
+        else:
+            request.session.flash('User "%s" not found!' % username)
+    all_users = session.query(User).order_by('username').all()
+    return dict(job=job, all_users=all_users)
+
 @view_config(route_name='profile', renderer='user.mako', permission='edit')
 def profile(request):
     session = DBSession()

--- a/OSMTM/views/views.py
+++ b/OSMTM/views/views.py
@@ -126,6 +126,7 @@ def job_new(request):
         job.geometry = request.params['geometry']
         job.workflow = request.params['workflow']
         job.zoom = request.params['zoom']
+        job.is_private = request.params['is_private']
 
         tiles = []
         for i in get_tiles_in_geom(loads(job.geometry), int(job.zoom)):


### PR DESCRIPTION
This set of patches adds the ability to mark a job as private, and to create a whitelist of users permitted to interact with a private job. Users who are not admins and are not on the whitelist for a private job cannot see or modify that job.

The authorization model ('context' in Pyramid lingo) for jobs is implemented in the OSMTM.resources module.
