### PR TITLE
NextView license acknowledgement

### DIFF
--- a/OSMTM/__init__.py
+++ b/OSMTM/__init__.py
@@ -37,6 +37,7 @@ def main(global_config, **settings):
     config.add_route('task_take', '/job/{job}/take', factory='OSMTM.resources.JobFactory')
     config.add_route('profile', '/profile')
     config.add_route('profile_update', '/profile/update')
+    config.add_route('nextview', '/profile/nextview')
     config.add_route('user', '/user/{id}')
     config.add_route('user_update', '/user/{id}/update')
     config.add_route('users', '/users')

--- a/OSMTM/models.py
+++ b/OSMTM/models.py
@@ -90,20 +90,26 @@ class Job(Base):
     description = Column(Unicode)
     geometry = Column(Unicode)
     workflow = Column(Unicode)
+    imagery = Column(Unicode)
     zoom = Column(Integer)
     is_private = Column(Boolean)
+    requires_nextview = Column(Boolean)
     tiles = relationship(Tile, backref='job')
     users = relationship(User,
                 secondary=job_whitelist_table,
                 backref='private_jobs')
 
-    def __init__(self, title=None, description=None, geometry=None, workflow=None, zoom=None, is_private=False):
+    def __init__(self, title=None, description=None, geometry=None,
+                 workflow=None, zoom=None, is_private=False, imagery=None,
+                 requires_nextview=False):
         self.title = title
         self.description = description
         self.geometry = geometry
         self.workflow = workflow
+        self.imagery = imagery
         self.zoom = zoom
         self.is_private = is_private
+        self.requires_nextview = requires_nextview
 
 def group_membership(username, request):
     session = DBSession()
@@ -121,7 +127,7 @@ def populate():
     session = DBSession()
     user = User('foo', 1)
     session.add(user)
-    job = Job('SomeTitle', 'Some description', 'Some workflow', 'Some geometry', 10, False)
+    job = Job('SomeTitle', 'Some description', 'Some workflow', 'Some geometry', 10, False, 'Some URL', False)
     session.add(job)
     
 def initialize_sql(engine):

--- a/OSMTM/models.py
+++ b/OSMTM/models.py
@@ -73,11 +73,13 @@ class User(Base):
     __tablename__ = "users"
     username = Column(Unicode, primary_key=True)
     role = Column(Integer) # 1 - newbie, 2 - advanced, 3 - admin
+    accepted_nextview = Column(Boolean)
     task = relationship(Tile, backref='user')
 
-    def __init__(self, username, role=1):
+    def __init__(self, username, role=1, accepted_nextview=False):
         self.username = username
         self.role = role
+        self.accepted_nextview = accepted_nextview
 
     def is_admin(self):
         return self.role == 3

--- a/OSMTM/templates/job.mako
+++ b/OSMTM/templates/job.mako
@@ -8,19 +8,19 @@
         <p>${job.description|n}</p>
         <h3>Workflow</h3>
         <p>${job.workflow|n}</p>
-        % if job.imagery
+        % if job.imagery:
         <h3>Imagery URL</h3>
-        % if job.requires_nextview
+        % if job.requires_nextview:
         <p>Access to this imagery is limited by the
         <a href="${request.route_url('nextview')}?redirect=${request.route_url('job',job=job.id)}">NextView license agreement</a>.
-        % if not accepted_nextview
+        % if not accepted_nextview:
         You may
         <a href="${request.route_url('nextview')}?redirect=${request.route_url('job',job=job.id)}">review and acknowledge</a>
         the agreement, if you like.
         % endif
         </p>
         % endif
-        % if accepted_nextview or not job.requires_nextview
+        % if accepted_nextview or not job.requires_nextview:
         <p>${job.imagery}</p>
         % endif
         % endif

--- a/OSMTM/templates/job.mako
+++ b/OSMTM/templates/job.mako
@@ -10,11 +10,18 @@
         <p>${job.workflow|n}</p>
         % if job.imagery
         <h3>Imagery URL</h3>
+        % if job.requires_nextview
+        <p>Access to this imagery is limited by the
+        <a href="${request.route_url('nextview')}?redirect=${request.route_url('job',job=job.id)}">NextView license agreement</a>.
+        % if not accepted_nextview
+        You may
+        <a href="${request.route_url('nextview')}?redirect=${request.route_url('job',job=job.id)}">review and acknowledge</a>
+        the agreement, if you like.
+        % endif
+        </p>
+        % endif
         % if accepted_nextview or not job.requires_nextview
         <p>${job.imagery}</p>
-        % endif
-        % if job.requires_nextview
-        <p>Access to this imagery is limited by the <a href="${request.route_url('nextview')}">NextView license agreement</a>.</p>
         % endif
         % endif
         <hr />

--- a/OSMTM/templates/job.mako
+++ b/OSMTM/templates/job.mako
@@ -8,8 +8,17 @@
         <p>${job.description|n}</p>
         <h3>Workflow</h3>
         <p>${job.workflow|n}</p>
-        % if not admin:
+        % if job.imagery
+        <h3>Imagery URL</h3>
+        % if accepted_nextview or not job.requires_nextview
+        <p>${job.imagery}</p>
+        % endif
+        % if job.requires_nextview
+        <p>Access to this imagery is limited by the <a href="${request.route_url('nextview')}">NextView license agreement</a>.</p>
+        % endif
+        % endif
         <hr />
+        % if not admin:
         % if current_task:
             <p>You are currently working on
             <a href="${request.route_url('task', job=current_task.job_id, x=current_task.x, y=current_task.y)}">

--- a/OSMTM/templates/job.new.mako
+++ b/OSMTM/templates/job.new.mako
@@ -24,6 +24,13 @@
             <label for="id_workflow">Workflow</label> 
             <textarea class="text" id="id_workflow" name="workflow"></textarea> 
             </div> 
+            <label for="id_imagery">Imagery URL</label>
+            <input type="text" class="text" id="id_imagery" name="imagery" value="" />
+            </div>
+            <div class="field">
+            <label for="id_requires_nextview">Imagery requires NextView license agreement?</label>
+            <input type="checkbox" id="id_requires_nextview" name="requires_nextview" value="1" />
+            </div>
             <div class="field">
             <label for="id_zoom">Zoom level</label> 
             <select id="id_zoom" name="zoom">

--- a/OSMTM/templates/job.new.mako
+++ b/OSMTM/templates/job.new.mako
@@ -24,11 +24,12 @@
             <label for="id_workflow">Workflow</label> 
             <textarea class="text" id="id_workflow" name="workflow"></textarea> 
             </div> 
+            <div class="field"> 
             <label for="id_imagery">Imagery URL</label>
             <input type="text" class="text" id="id_imagery" name="imagery" value="" />
             </div>
             <div class="field">
-            <label for="id_requires_nextview">Imagery requires NextView license agreement?</label>
+            <label for="id_requires_nextview">Requires NextView?</label>
             <input type="checkbox" id="id_requires_nextview" name="requires_nextview" value="1" />
             </div>
             <div class="field">

--- a/OSMTM/templates/nextview.mako
+++ b/OSMTM/templates/nextview.mako
@@ -8,6 +8,7 @@
         <p>“This data is licensed for use by the US Government (USG) under the NextView (NV) license and copyrighted by Digital Globe or GeoEye. The NV license allows the USG to share the imagery and Literal Imagery Derived Products (LIDP) with entities outside the USG when that entity is working directly with the USG, for the USG, or in a manner that is directly beneficial to the USG. The party receiving the data can only use the imagery or LIDP for the original purpose or only as otherwise agreed to by the USG.  The party receiving the data cannot share the imagery or LIDP with a third party without express permission from the USG.  At no time should this imagery or LIDP be used for other than USG-related purposes and must not be used for commercial gain. The copyright information should be maintained at all times.  Your acceptance of these license terms is implied by your use.”</p>
         <p>In other words, you may only use NextView imagery linked from this site for digitizing OpenStreetMap data for humanitarian purposes.</p>
         <form method="post" action="">
+            <input type="hidden" name="redirect" value="${redirect}" /><!-- to get back to from whence you came -->
             <input type="submit" name="accepted_terms" value="I AGREE"/>
             <input type="submit" name="accepted_terms" value="No, thank you"/>
         </form>

--- a/OSMTM/templates/nextview.mako
+++ b/OSMTM/templates/nextview.mako
@@ -5,12 +5,16 @@
     <section class="user">
         <h1>NextView License Acknowledgement</h1>
         <p>Access via this site to imagery identified as "NextView" is subject to the following usage terms:</p>
-        <p>“This data is licensed for use by the US Government (USG) under the NextView (NV) license and copyrighted by Digital Globe or GeoEye. The NV license allows the USG to share the imagery and Literal Imagery Derived Products (LIDP) with entities outside the USG when that entity is working directly with the USG, for the USG, or in a manner that is directly beneficial to the USG. The party receiving the data can only use the imagery or LIDP for the original purpose or only as otherwise agreed to by the USG.  The party receiving the data cannot share the imagery or LIDP with a third party without express permission from the USG.  At no time should this imagery or LIDP be used for other than USG-related purposes and must not be used for commercial gain. The copyright information should be maintained at all times.  Your acceptance of these license terms is implied by your use.”</p>
+        <hr />
+        <p><em>“This data is licensed for use by the US Government (USG) under the NextView (NV) license and copyrighted by Digital Globe or GeoEye. The NV license allows the USG to share the imagery and Literal Imagery Derived Products (LIDP) with entities outside the USG when that entity is working directly with the USG, for the USG, or in a manner that is directly beneficial to the USG. The party receiving the data can only use the imagery or LIDP for the original purpose or only as otherwise agreed to by the USG.  The party receiving the data cannot share the imagery or LIDP with a third party without express permission from the USG.  At no time should this imagery or LIDP be used for other than USG-related purposes and must not be used for commercial gain. The copyright information should be maintained at all times.  Your acceptance of these license terms is implied by your use.”</em></p>
+        <hr />
         <p>In other words, you may only use NextView imagery linked from this site for digitizing OpenStreetMap data for humanitarian purposes.</p>
+        <div>
         <form method="post" action="">
             <input type="hidden" name="redirect" value="${redirect}" /><!-- to get back to from whence you came -->
             <input type="submit" name="accepted_terms" value="I AGREE"/>
             <input type="submit" name="accepted_terms" value="No, thank you"/>
         </form>
+        </div>
     </section>
 </div>

--- a/OSMTM/templates/nextview.mako
+++ b/OSMTM/templates/nextview.mako
@@ -1,0 +1,15 @@
+<%inherit file="/base.mako"/>
+<%def name="id()">nextview</%def>
+<%def name="title()">NextView License Acknowledgement</%def>
+<div class="content group wrap">
+    <section class="user">
+        <h1>NextView License Acknowledgement</h1>
+        <p>Access via this site to imagery identified as "NextView" is subject to the following usage terms:</p>
+        <p>“This data is licensed for use by the US Government (USG) under the NextView (NV) license and copyrighted by Digital Globe or GeoEye. The NV license allows the USG to share the imagery and Literal Imagery Derived Products (LIDP) with entities outside the USG when that entity is working directly with the USG, for the USG, or in a manner that is directly beneficial to the USG. The party receiving the data can only use the imagery or LIDP for the original purpose or only as otherwise agreed to by the USG.  The party receiving the data cannot share the imagery or LIDP with a third party without express permission from the USG.  At no time should this imagery or LIDP be used for other than USG-related purposes and must not be used for commercial gain. The copyright information should be maintained at all times.  Your acceptance of these license terms is implied by your use.”</p>
+        <p>In other words, you may only use NextView imagery linked from this site for digitizing OpenStreetMap data for humanitarian purposes.</p>
+        <form method="post" action="">
+            <input type="submit" name="accepted_terms" value="I AGREE"/>
+            <input type="submit" name="accepted_terms" value="No, thank you"/>
+        </form>
+    </section>
+</div>

--- a/OSMTM/templates/user.mako
+++ b/OSMTM/templates/user.mako
@@ -33,11 +33,11 @@
 	    % endif
             </div>
             <div>
-            % if admin
+            % if admin:
                 <input type="checkbox" id="id_accepted_nextview" name="accepted_nextview" value="1" />
-                Accepted NextView license agreement?
-            % elif user.accepted_nextview
-                You have accepted the NextView license agreement.
+                Acknowledged NextView license terms?
+            % elif user.accepted_nextview:
+                You have acknowledged the NextView license terms.
             % endif
             </div>
             <input type="submit" name="form.submitted" value="Apply changes"/>

--- a/OSMTM/templates/user.mako
+++ b/OSMTM/templates/user.mako
@@ -10,6 +10,7 @@
         <h1>Profile</h1>
         <form method="post" action="${request.route_url('profile_update')}">
         % endif
+            <div>
             <input type="radio" id="role_1" name="role" value="1"
                 % if user.role == 1:
                 checked="checked"
@@ -30,6 +31,15 @@
             />
             <label for="role_3">Admin</label>
 	    % endif
+            </div>
+            <div>
+            % if admin
+                <input type="checkbox" id="id_accepted_nextview" name="accepted_nextview" value="1" />
+                Accepted NextView license agreement?
+            % elif user.accepted_nextview
+                You have accepted the NextView license agreement.
+            % endif
+            </div>
             <input type="submit" name="form.submitted" value="Apply changes"/>
         </form>
     </section>

--- a/OSMTM/views/views.py
+++ b/OSMTM/views/views.py
@@ -128,8 +128,10 @@ def job_new(request):
         job.description = request.params['description']
         job.geometry = request.params['geometry']
         job.workflow = request.params['workflow']
+        job.imagery = request.params['imagery']
         job.zoom = request.params['zoom']
         job.is_private = request.params.get('is_private', 0)
+        job.requires_nextview = request.params.get('requires_nextview', 0)
 
         tiles = []
         for i in get_tiles_in_geom(loads(job.geometry), int(job.zoom)):

--- a/OSMTM/views/views.py
+++ b/OSMTM/views/views.py
@@ -207,6 +207,17 @@ def profile_update(request):
         request.session.flash('Profile correctly updated!')
     return HTTPFound(location=request.route_url('profile'))
 
+@view_config(route_name='nextview', renderer='nextview.mako', permission='edit')
+def nextview(request):
+    session = DBSession()
+    username = authenticated_userid(request)
+    user = session.query(User).get(username)
+    if "accepted_terms" in request.params:
+        user.accepted_nextview = request.params["accepted_terms"] == "I AGREE"
+        return HTTPFound(location=request.route_url('profile'))
+    else:
+        return dict(user=user)
+
 @view_config(route_name='user', renderer='user.mako', permission='admin')
 def user(request):
     session = DBSession()

--- a/OSMTM/views/views.py
+++ b/OSMTM/views/views.py
@@ -170,10 +170,12 @@ def job(request):
     username = authenticated_userid(request)
     user = session.query(User).get(username)
     admin = user.is_admin() if user else False
+    accepted_nextview = user.accepted_nextview if user else False
     stats = get_stats(job) if admin else None
     return dict(job=job, tiles=dumps(FeatureCollection(tiles)),
             current_task=current_task,
             admin=admin,
+            accepted_nextview=accepted_nextview,
             stats=stats)
 
 @view_config(route_name='job_users', renderer='job.users.mako', permission='admin')
@@ -235,7 +237,7 @@ def user_update(request):
     user = session.query(User).get(request.matchdict["id"])
     if 'form.submitted' in request.params:
         user.role = request.params['role']
-        user.role = request.params.get('accepted_nextview', 0)
+        user.accepted_nextview = request.params.get('accepted_nextview', 0)
         session.flush()
         request.session.flash('Profile correctly updated!')
     return HTTPFound(location=request.route_url('user',id=user.username))

--- a/OSMTM/views/views.py
+++ b/OSMTM/views/views.py
@@ -219,6 +219,7 @@ def user_update(request):
     user = session.query(User).get(request.matchdict["id"])
     if 'form.submitted' in request.params:
         user.role = request.params['role']
+        user.role = request.params.get('accepted_nextview', 0)
         session.flush()
         request.session.flash('Profile correctly updated!')
     return HTTPFound(location=request.route_url('user',id=user.username))

--- a/OSMTM/views/views.py
+++ b/OSMTM/views/views.py
@@ -212,11 +212,12 @@ def nextview(request):
     session = DBSession()
     username = authenticated_userid(request)
     user = session.query(User).get(username)
+    redirect = request.params.get("redirect", request.route_url("profile"))
     if "accepted_terms" in request.params:
         user.accepted_nextview = request.params["accepted_terms"] == "I AGREE"
-        return HTTPFound(location=request.route_url('profile'))
+        return HTTPFound(location=redirect)
     else:
-        return dict(user=user)
+        return dict(user=user, redirect=redirect)
 
 @view_config(route_name='user', renderer='user.mako', permission='admin')
 def user(request):


### PR DESCRIPTION
These patches add the ability to include an imagery source with each job, and to mark the imagery source as requiring acknowledgement of the US government's NextView license. The User model has been modified to include a flag, so that users only need to acknowledge their understanding of the imagery access terms once.
