### PR TITLE
Fixing typo in tab on job: "Worflow" --> "Workflow"

### DIFF
--- a/OSMTM/templates/job.mako
+++ b/OSMTM/templates/job.mako
@@ -12,7 +12,7 @@
     <div class="span6">
         <ul class="nav nav-tabs">
             <li class="active"><a href="#description" data-toggle="tab">Description</a></li>
-            <li><a href="#workflow" data-toggle="tab">Worflow</a></li>
+            <li><a href="#workflow" data-toggle="tab">Workflow</a></li>
             <li><a href="#task" id="task_tab" data-toggle="tab">Task</a></li>
             <li><a href="#users" data-toggle="tab">Users</a></li>
             <li><a href="#chart" data-toggle="tab">Stats</a></li>


### PR DESCRIPTION
This was just a really really minor thing that was bugging me.  Thanks!
