### PR TITLE
Add editing and viewing links for iD

### DIFF
--- a/OSMTM/static/js/task.js
+++ b/OSMTM/static/js/task.js
@@ -58,8 +58,27 @@ var exportOpen = function() {
         });
         window.open(url);
         break;
+    case "id":
+        url = getLink({
+            base: 'http://www.openstreetmap.org/edit?editor=id&',
+            bounds: bounds,
+            zoom: zoom,
+            protocol: 'llz'
+        });
+        window.open(url);
+        break;
     default:
         break;
     }
 };
+var exportForID = function(jquery_obj) {
+    var convertedObject = OpenLayers.Geometry.fromWKT(jquery_obj.data('geometry'))
+    var values =  OpenLayers.Projection.transform(
+        convertedObject.getCentroid(),
+        new OpenLayers.Projection("EPSG:900913"), 
+        new OpenLayers.Projection("EPSG:4326")
+    )
+    return jquery_obj.attr('href') + values.x + "/" +values.y;
+};
 $('#export a').live('click', exportOpen);
+$('#id_imagery').attr('href', exportForID($('#id_imagery')));

--- a/OSMTM/templates/imagery.mako
+++ b/OSMTM/templates/imagery.mako
@@ -8,6 +8,7 @@
     type = job.imagery.lower()[:3]
 %>
 <p><pre><a href='http://127.0.0.1:8111/imagery?title=${job.title}&type=${type}&url=${job.imagery}' target="_blank" rel="tooltip" data-original-title="If you have JOSM running and remote control activated, clicking this link should automatically load imagery.">${job.imagery}</a></pre></p>
+<p><a class="btn" id="id_imagery" data-geometry="${job.geometry}" href="http://openstreetmap.us/iD/release/#background=custom:${job.imagery}&map=${job.zoom}/">View in iD</a></p>
 % endif
 % if job.license:
 <div class="alert ${'alert-error' if not license_accepted else ''}">

--- a/OSMTM/templates/task.mako
+++ b/OSMTM/templates/task.mako
@@ -16,6 +16,7 @@
                                 <a class="btn btn-small btn-info" id="josm" rel="tooltip" data-original-title="If you have JOSM already running, click this button should load data for the area of the current task,">JOSM</a>
                                 <a class="btn btn-small btn-info" id="potlatch2">Potlatch 2</a>
                                 <a class="btn btn-small btn-info" href="javascript:void(0);" id="wp">Walking Papers</a>
+                                <a class="btn btn-small btn-info" href="javascript:void(0);" id="id">iD</a>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
Regular edit button in alongside PL2, JOSM and WP buttons, but probably needs work in the imagery side of things to make it support more formats.
