### PR TITLE
Different popups for Validate and Invalidate

### DIFF
--- a/OSMTM/static/js/job.js
+++ b/OSMTM/static/js/job.js
@@ -363,6 +363,14 @@ $('form').live('submit', function(e) {
         });
     }
     if ($(form).has($('#commentModal')).length > 0) {
+        if($("button[type=submit][clicked=true]").val() == "Validate"){
+          $(form).find(".comment").show();
+          $(form).find(".invalidate").hide();
+        }
+        else if($("button[type=submit][clicked=true]").val() == "Invalidate"){
+          $(form).find(".comment").hide();
+          $(form).find(".invalidate").show();
+        }
         $('#commentModal').modal('show');
         $('#task_comment').focus();
         // we need to be sure there is only one click event binded

--- a/OSMTM/templates/task.mako
+++ b/OSMTM/templates/task.mako
@@ -37,7 +37,8 @@ else:
                     if tile.username == user.username:
                         comment_label = 'Please add a comment'
                     else:
-                        comment_label = 'Please write why you marked this tile as invalid so that the user may eventually correct his mistakes if any.'
+                        comment_label = 'Please add a comment'
+                        invalidate_label = 'Please write why you marked this tile as invalid so that the user may eventually correct his mistakes if any.'
                 %>
             <form class="form-horizontal" method="POST">
                 % if tile.username == user.username:
@@ -68,7 +69,10 @@ else:
                     <div class="modal-header">
                         <h3 id="commentModalLabel">Comment?
                         </h3>
-                        <p>${comment_label}</p>
+                        <p class="comment">${comment_label}</p>
+                        % if invalidate_label is not UNDEFINED:
+                          <p class="invalidate">${invalidate_label}</p>
+                        % endif
                     </div>
                     <div class="modal-body">
                         <textarea id="task_comment" name="comment" class="span6" placeholder="Your comment here"></textarea>


### PR DESCRIPTION
Whether you click Validate or Invalidate, the current popup says "Please write why you marked this tile as invalid so that the user may eventually correct his mistakes if any."

This pull request shows a different string for Validate (currently the same used when marking a task as done: `Please add a comment`)
